### PR TITLE
fix: enable CGO and debug symbols for proper build on Arch Linux

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -8,17 +8,17 @@ pkgdesc="Native Linux backend for Claude Desktop Cowork"
 arch=('x86_64')
 url="https://github.com/patrickjaja/claude-cowork-service"
 license=('MIT')
-
 depends=('systemd' 'util-linux')
 makedepends=('go')
-
+options=('debug')
 install="${pkgname}.install"
-
 source=("${pkgname}-${pkgver}.tar.gz::${url}/archive/v${pkgver}.tar.gz")
 sha256sums=('15b104b1c8db86dfa9821c05991a1173a41769c15ca3ba83c5d2895fb3e6040b')
 
 build() {
     cd "${srcdir}/${pkgname}-${pkgver}"
+    export CGO_ENABLED=1
+    export GOFLAGS="-trimpath"
     make VERSION="${pkgver}"
 }
 


### PR DESCRIPTION
## Problem

Building on Arch Linux fails because makepkg injects hardening flags
(`-Wl,-O1`, `--sort-common`, etc.) into `LDFLAGS`, which are incompatible
with Go's internal linker when `CGO_ENABLED=0`.

Additionally, the `-debug` split package could not be generated due to
missing debug symbols.

## Changes

- Set `CGO_ENABLED=1` to use the external linker, making it compatible
  with the host's `LDFLAGS`
- Set `GOFLAGS="-trimpath"` to avoid duplicating the flag already in the
  Makefile
- Add `options=('debug')` to enable automatic debug symbol splitting by
  makepkg

## Tested on

- Arch Linux x86_64 via AUR (`makepkg -si`)