### PR TITLE
feat: add claude-code dependency and claude-desktop-bin optdepend

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,13 +3,14 @@
 
 pkgname=claude-cowork-service
 pkgver=1.0.0
-pkgrel=3
+pkgrel=1
 pkgdesc="Native Linux backend for Claude Desktop Cowork"
 arch=('x86_64')
 url="https://github.com/patrickjaja/claude-cowork-service"
 license=('MIT')
 
 depends=('systemd' 'util-linux' 'claude-code')
+optdepends=('claude-desktop-bin: Unofficial Linux frontend for Claude Desktop Cowork')
 makedepends=('go')
 
 install="${pkgname}.install"


### PR DESCRIPTION
## Changes

- Add `claude-code` as a runtime dependency
- Add `claude-desktop-bin` as an optional dependency for the unofficial Linux frontend (Claude Desktop Cowork)
- Reset `pkgrel` to 1

## Rationale

`claude-code` is now required for the package to function properly.
`claude-desktop-bin` is offered as an optional dependency for users
who want the Claude Desktop Cowork interface on Linux.