### PR TITLE
feat: graceful shutdown, broken pipe prevention, and session integrity checks

### DIFF
--- a/native/backend.go
+++ b/native/backend.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -135,15 +137,32 @@ func (b *Backend) StartVM(name string, bundlePath string, memoryGB int) error {
 }
 
 func (b *Backend) StopVM(name string) error {
+	if b.debug {
+		log.Printf("[native] stopVM %s — initiating graceful shutdown", name)
+	}
+
+	// Backup session files before killing processes.
+	// This preserves the queue JSONL state in case the graceful drain
+	// in kill() doesn't complete before the process is terminated.
+	home, _ := os.UserHomeDir()
+	sessionDir := filepath.Join(home, ".local", "share", "claude-cowork", "sessions", name)
+	if _, err := os.Stat(sessionDir); err == nil {
+		backupDir := sessionDir + ".pre-stop-" + time.Now().Format("20060102-150405")
+		if cpErr := exec.Command("cp", "-a", sessionDir, backupDir).Run(); cpErr != nil {
+			log.Printf("[native] WARNING: pre-stop backup failed: %v", cpErr)
+		} else {
+			log.Printf("[native] pre-stop backup created: %s", backupDir)
+			// Prune old backups: keep only the 5 most recent
+			go pruneBackups(sessionDir, 5)
+		}
+	}
+
 	b.mu.Lock()
 	b.started = false
 	b.mu.Unlock()
 
 	b.tracker.killAll()
 
-	if b.debug {
-		log.Printf("[native] stopVM %s", name)
-	}
 	b.emitEvent(map[string]string{"type": "vmStopped", "name": name})
 	return nil
 }
@@ -559,5 +578,40 @@ func (b *Backend) emitEvent(event interface{}) {
 
 	for _, cb := range subs {
 		go cb(event)
+	}
+}
+
+// pruneBackups removes old pre-stop backup directories, keeping only the
+// `keep` most recent ones. Backups are identified by the ".pre-stop-" suffix
+// pattern in the session directory's parent.
+func pruneBackups(sessionDir string, keep int) {
+	parent := filepath.Dir(sessionDir)
+	base := filepath.Base(sessionDir)
+	prefix := base + ".pre-stop-"
+
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		return
+	}
+
+	var backups []string
+	for _, e := range entries {
+		if e.IsDir() && strings.HasPrefix(e.Name(), prefix) {
+			backups = append(backups, filepath.Join(parent, e.Name()))
+		}
+	}
+
+	// Sort lexicographically (timestamp suffix ensures chronological order)
+	sort.Strings(backups)
+
+	// Remove oldest backups, keeping `keep` most recent
+	if len(backups) > keep {
+		for _, old := range backups[:len(backups)-keep] {
+			if err := os.RemoveAll(old); err != nil {
+				log.Printf("[native] failed to prune backup %s: %v", old, err)
+			} else {
+				log.Printf("[native] pruned old backup: %s", old)
+			}
+		}
 	}
 }

--- a/native/backend.go
+++ b/native/backend.go
@@ -121,6 +121,11 @@ func (b *Backend) StartVM(name string, bundlePath string, memoryGB int) error {
 
 	log.Printf("[native] startVM %s — running natively on host", name)
 
+	// Run session integrity checks in background (non-blocking).
+	// Scans for half-written JSONL files, orphaned pre-stop backups,
+	// and other signs of previous unclean shutdown.
+	go b.checkSessionIntegrity(name)
+
 	// Emit startup events asynchronously to avoid race with subscribeEvents
 	// (both calls arrive simultaneously on different connections)
 	go func() {
@@ -578,6 +583,65 @@ func (b *Backend) emitEvent(event interface{}) {
 
 	for _, cb := range subs {
 		go cb(event)
+	}
+}
+
+// checkSessionIntegrity runs background integrity checks on session files
+// for the given VM name. This detects signs of previous unclean shutdowns
+// (truncated JSONL, orphaned backups) and logs warnings.
+//
+// This intentionally does NOT auto-repair — that's left to cowork-session-doctor
+// which can be run interactively. We only log diagnostics here.
+func (b *Backend) checkSessionIntegrity(name string) {
+	home, _ := os.UserHomeDir()
+	sessionsDir := filepath.Join(home, ".local", "share", "claude-cowork", "sessions")
+
+	if _, err := os.Stat(sessionsDir); err != nil {
+		return
+	}
+
+	entries, err := os.ReadDir(sessionsDir)
+	if err != nil {
+		return
+	}
+
+	backupCount := 0
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		eName := e.Name()
+
+		// Count orphaned pre-stop backups
+		if strings.Contains(eName, ".pre-stop-") {
+			backupCount++
+			continue
+		}
+
+		// Check session directories for JSONL integrity
+		sessionDir := filepath.Join(sessionsDir, eName)
+		auditPath := filepath.Join(sessionDir, "audit.jsonl")
+		if info, err := os.Stat(auditPath); err == nil {
+			if info.Size() == 0 {
+				log.Printf("[native] INTEGRITY WARNING: empty audit.jsonl in session %s", eName)
+			} else {
+				// Check if audit.jsonl ends with a complete line (no truncation)
+				f, err := os.Open(auditPath)
+				if err == nil {
+					buf := make([]byte, 1)
+					f.Seek(info.Size()-1, 0)
+					n, _ := f.Read(buf)
+					if n > 0 && buf[0] != '\n' {
+						log.Printf("[native] INTEGRITY WARNING: audit.jsonl in session %s may be truncated (no trailing newline)", eName)
+					}
+					f.Close()
+				}
+			}
+		}
+	}
+
+	if backupCount > 0 {
+		log.Printf("[native] startup: found %d pre-stop backup(s) in %s", backupCount, sessionsDir)
 	}
 }
 

--- a/native/process.go
+++ b/native/process.go
@@ -33,6 +33,8 @@ type localProcess struct {
 	stdin             io.WriteCloser
 	done              chan struct{}
 	exitCode          int
+	ready             chan struct{} // closed when first output received, signaling stdin is safe
+	readyOnce         sync.Once    // ensures ready is closed exactly once
 	mu                sync.Mutex
 	vmPrefix          []byte      // e.g. "/sessions/optimistic-nice-brahmagupta"
 	realPrefix        []byte      // e.g. "/home/user/.local/share/claude-cowork/sessions/optimistic-nice-brahmagupta"
@@ -177,6 +179,7 @@ func (pt *processTracker) spawn(id string, cmd string, args []string, env map[st
 		cmd:               c,
 		stdin:             stdin,
 		done:              make(chan struct{}),
+		ready:             make(chan struct{}),
 		mountRemap:        mountRemap,
 		reverseMountRemap: reverseMountRemap,
 	}
@@ -278,6 +281,15 @@ func (pt *processTracker) streamOutput(id string, r io.Reader, stream string) {
 	scanner.Buffer(make([]byte, 64*1024), 10*1024*1024) // 10MB max for large Opus stream-json lines
 	for scanner.Scan() {
 		line := scanner.Text() + "\n"
+
+		// Signal that the CLI process is alive and producing output.
+		// writeStdin waits on this before sending data to avoid broken pipe
+		// errors when Desktop writes stdin before the CLI has initialized.
+		if lp != nil {
+			lp.readyOnce.Do(func() {
+				close(lp.ready)
+			})
+		}
 
 		// Remap real paths → VM paths in output (only when /sessions/ is accessible).
 		// Without this guard, native Linux (no root) would produce /sessions/ paths
@@ -644,6 +656,19 @@ func (pt *processTracker) writeStdin(processID string, data []byte) error {
 	case <-lp.done:
 		return fmt.Errorf("process %s has exited", processID)
 	default:
+	}
+
+	// Wait for the CLI to be ready before writing stdin.
+	// The broken pipe race condition occurs when Desktop sends stdin data
+	// before the CLI has fully initialized. We wait for the first output
+	// from the CLI (which signals it's alive and processing) before writing.
+	select {
+	case <-lp.ready:
+		// CLI is ready
+	case <-lp.done:
+		return fmt.Errorf("process %s exited before becoming ready", processID)
+	case <-time.After(5 * time.Second):
+		log.Printf("[native] WARNING: %s not ready after 5s, proceeding with stdin write anyway", processID)
 	}
 
 	// Write with timeout to avoid blocking forever if stdin buffer is full

--- a/native/process.go
+++ b/native/process.go
@@ -491,6 +491,12 @@ func (pt *processTracker) tryHandlePresentFiles(lp *localProcess, line string) b
 }
 
 // kill sends a signal to a process. If signal is empty, defaults to SIGTERM.
+//
+// For SIGTERM (the default), we first attempt a graceful shutdown by sending
+// SIGINT and waiting up to 3 seconds for the process to exit. This allows the
+// Claude CLI to flush pending tool results to the queue JSONL file, preventing
+// session data loss from mid-stream kills (the root cause of session corruption
+// where the queue file gets truncated while a tool execution is in progress).
 func (pt *processTracker) kill(processID string, signal string) error {
 	pt.mu.RLock()
 	lp, ok := pt.processes[processID]
@@ -505,6 +511,23 @@ func (pt *processTracker) kill(processID string, signal string) error {
 	}
 
 	sig := mapSignal(signal)
+
+	// For non-SIGKILL signals, attempt graceful shutdown first:
+	// 1. Send SIGINT (Claude CLI handles this and flushes pending writes)
+	// 2. Wait up to 3 seconds for the process to exit cleanly
+	// 3. If still running, escalate to the requested signal on the process group
+	if sig != syscall.SIGKILL {
+		log.Printf("[native] graceful drain: sending SIGINT to %s, waiting up to 3s for flush", processID)
+		lp.cmd.Process.Signal(syscall.SIGINT)
+
+		select {
+		case <-lp.done:
+			log.Printf("[native] graceful drain: %s exited cleanly after SIGINT", processID)
+			return nil
+		case <-time.After(3 * time.Second):
+			log.Printf("[native] graceful drain: %s did not exit in 3s, escalating to %s", processID, signalName(sig))
+		}
+	}
 
 	// Kill the entire process group
 	pgid, err := syscall.Getpgid(lp.cmd.Process.Pid)

--- a/scripts/cowork-session-doctor/README.md
+++ b/scripts/cowork-session-doctor/README.md
@@ -1,0 +1,46 @@
+# cowork-session-doctor
+
+Diagnostic, repair, and recovery tool for Claude Desktop Cowork sessions.
+
+## Usage
+
+```bash
+# Analyze session health
+cowork-session-doctor diagnose <session-dir>
+
+# Repair queue file issues (auto-backup first)
+cowork-session-doctor repair <session-dir>
+cowork-session-doctor repair <session-dir> --dry-run
+
+# Extract human-readable transcript
+cowork-session-doctor extract <session-dir>
+cowork-session-doctor extract <session-dir> -o transcript.md
+
+# List artifacts created during session
+cowork-session-doctor extract <session-dir> --artifacts-only
+
+# Create timestamped backup
+cowork-session-doctor backup <session-dir>
+
+# Validate JSONL file integrity
+cowork-session-doctor validate <path-to-file.jsonl>
+```
+
+## What It Checks
+
+- **JSONL validity**: Every line must be valid JSON
+- **UUID chain**: `parentUuid` references must point to existing entries
+- **Stop reason**: Last assistant message must have `stop_reason` set
+- **Schema**: `tool_result` content must be array format, not string
+- **Session ID**: All entries must reference the correct session
+- **Synthetic entries**: Detects dummy/repair-injected messages
+- **Orphaned tools**: `tool_use` without matching `tool_result`
+
+## Session File Locations
+
+| File | Path |
+|------|------|
+| Session dir | `~/.config/Claude/local-agent-mode-sessions/<workspace>/<space>/local_<id>/` |
+| Manifest | `local_<id>.json` (sibling of session dir) |
+| Audit log | `local_<id>/audit.jsonl` |
+| Queue file | `local_<id>/.claude/projects/<encoded-path>/<id>.jsonl` |

--- a/scripts/cowork-session-doctor/pyproject.toml
+++ b/scripts/cowork-session-doctor/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "cowork-session-doctor"
+version = "0.1.0"
+description = "Diagnostic, repair, and recovery tool for Claude Desktop Cowork sessions"
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.11"
+authors = [
+    { name = "Cytognosis Foundation", email = "engineering@cytognosis.org" },
+]
+dependencies = []
+
+[project.scripts]
+cowork-session-doctor = "cowork_session_doctor.cli:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/cowork_session_doctor"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "S", "B", "C4", "SIM"]
+ignore = ["S603", "S607"]

--- a/scripts/cowork-session-doctor/src/cowork_session_doctor/__init__.py
+++ b/scripts/cowork-session-doctor/src/cowork_session_doctor/__init__.py
@@ -1,0 +1,3 @@
+"""Cowork Session Doctor — diagnostic, repair, and recovery tool for Claude Desktop Cowork sessions."""
+
+__version__ = "0.1.0"

--- a/scripts/cowork-session-doctor/src/cowork_session_doctor/cli.py
+++ b/scripts/cowork-session-doctor/src/cowork_session_doctor/cli.py
@@ -1,0 +1,159 @@
+"""CLI entry point for cowork-session-doctor."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from cowork_session_doctor.core import (
+    SessionPaths,
+    backup_session,
+    diagnose,
+    extract_artifacts_list,
+    extract_transcript,
+    repair_queue,
+    validate_jsonl,
+)
+
+
+def cmd_diagnose(args: argparse.Namespace) -> int:
+    """Run full diagnostic on a session."""
+    try:
+        paths = SessionPaths.from_session_dir(args.session_dir)
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    result = diagnose(paths)
+    print(result.format_report())
+    return 0 if result.is_healthy else 1
+
+
+def cmd_repair(args: argparse.Namespace) -> int:
+    """Repair queue file issues."""
+    try:
+        paths = SessionPaths.from_session_dir(args.session_dir)
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    if not args.no_backup:
+        backup_dir = backup_session(paths)
+        print(f"Backup created: {backup_dir}")
+
+    actions = repair_queue(paths, dry_run=args.dry_run)
+    for action in actions:
+        prefix = "[DRY RUN] " if args.dry_run else ""
+        print(f"{prefix}{action}")
+
+    return 0
+
+
+def cmd_extract(args: argparse.Namespace) -> int:
+    """Extract transcript and artifact list."""
+    try:
+        paths = SessionPaths.from_session_dir(args.session_dir)
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    output = Path(args.output) if args.output else None
+
+    if args.artifacts_only:
+        artifacts = extract_artifacts_list(paths)
+        if not artifacts:
+            print("No artifacts found in session.")
+            return 0
+        print(f"{'Path':<80} {'Op':<6} {'Exists':<8} {'Size'}")
+        print("-" * 110)
+        for a in artifacts:
+            print(f"{a['path']:<80} {a['operation']:<6} {a['exists']:<8} {a['size_bytes']}")
+        return 0
+
+    transcript = extract_transcript(paths, output_path=output)
+
+    if output:
+        print(f"Transcript written to: {output}")
+    else:
+        print(transcript)
+
+    return 0
+
+
+def cmd_backup(args: argparse.Namespace) -> int:
+    """Create a timestamped backup."""
+    try:
+        paths = SessionPaths.from_session_dir(args.session_dir)
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    backup_dir = Path(args.dest) if args.dest else None
+    result = backup_session(paths, backup_dir=backup_dir)
+    print(f"Backup created: {result}")
+    return 0
+
+
+def cmd_validate(args: argparse.Namespace) -> int:
+    """Validate a JSONL file."""
+    path = Path(args.file)
+    if not path.exists():
+        print(f"Error: File not found: {path}", file=sys.stderr)
+        return 1
+
+    issues = validate_jsonl(path)
+    if not issues:
+        print(f"✅ {path.name}: Valid ({sum(1 for _ in open(path))} lines)")
+        return 0
+
+    print(f"❌ {path.name}: {len(issues)} issue(s)")
+    for issue in issues:
+        print(f"  - {issue}")
+    return 1
+
+
+def main() -> None:
+    """Main CLI entry point."""
+    parser = argparse.ArgumentParser(
+        prog="cowork-session-doctor",
+        description="Diagnostic, repair, and recovery tool for Claude Desktop Cowork sessions",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # diagnose
+    p_diag = subparsers.add_parser("diagnose", help="Analyze session health")
+    p_diag.add_argument("session_dir", help="Path to session directory (local_<id>/ or parent)")
+    p_diag.set_defaults(func=cmd_diagnose)
+
+    # repair
+    p_repair = subparsers.add_parser("repair", help="Repair queue file issues")
+    p_repair.add_argument("session_dir", help="Path to session directory")
+    p_repair.add_argument("--dry-run", action="store_true", help="Show what would be done")
+    p_repair.add_argument("--no-backup", action="store_true", help="Skip pre-repair backup")
+    p_repair.set_defaults(func=cmd_repair)
+
+    # extract
+    p_extract = subparsers.add_parser("extract", help="Extract transcript and artifacts")
+    p_extract.add_argument("session_dir", help="Path to session directory")
+    p_extract.add_argument("--output", "-o", help="Output file path for transcript")
+    p_extract.add_argument("--artifacts-only", action="store_true", help="Only list artifacts")
+    p_extract.set_defaults(func=cmd_extract)
+
+    # backup
+    p_backup = subparsers.add_parser("backup", help="Create timestamped backup")
+    p_backup.add_argument("session_dir", help="Path to session directory")
+    p_backup.add_argument("--dest", help="Backup destination directory")
+    p_backup.set_defaults(func=cmd_backup)
+
+    # validate
+    p_validate = subparsers.add_parser("validate", help="Validate JSONL file integrity")
+    p_validate.add_argument("file", help="Path to JSONL file")
+    p_validate.set_defaults(func=cmd_validate)
+
+    args = parser.parse_args()
+    sys.exit(args.func(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cowork-session-doctor/src/cowork_session_doctor/core.py
+++ b/scripts/cowork-session-doctor/src/cowork_session_doctor/core.py
@@ -1,0 +1,539 @@
+"""Core session analysis and repair logic for Claude Desktop Cowork sessions.
+
+This module handles the three file types that constitute a Cowork session:
+- audit.jsonl: Cryptographic ledger of all conversation events (HMAC-signed)
+- queue JSONL: UI renderer source file (in .claude/projects/.../<session-id>.jsonl)
+- manifest JSON: Session metadata (local_<session-id>.json)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class SessionPaths:
+    """Resolved paths for all components of a Cowork session."""
+
+    session_dir: Path
+    manifest_json: Path
+    audit_jsonl: Path
+    queue_jsonl: Path | None = None
+    session_id: str = ""
+
+    @classmethod
+    def from_session_dir(cls, session_dir: str | Path) -> "SessionPaths":
+        """Discover all session files from a session directory path.
+
+        Accepts either:
+        - The session directory itself (local_<id>/)
+        - The parent directory containing it
+        """
+        session_dir = Path(session_dir)
+
+        # If given the parent dir, find the session dir
+        if not session_dir.name.startswith("local_"):
+            candidates = sorted(session_dir.glob("local_*/"), key=lambda p: p.stat().st_mtime, reverse=True)
+            if not candidates:
+                msg = f"No local_* session directories found in {session_dir}"
+                raise FileNotFoundError(msg)
+            session_dir = candidates[0]
+
+        # Extract session ID from directory name
+        session_id = session_dir.name.removeprefix("local_")
+
+        # Manifest JSON is a sibling of the session directory
+        manifest = session_dir.parent / f"{session_dir.name}.json"
+
+        # Audit JSONL is inside the session directory
+        audit = session_dir / "audit.jsonl"
+
+        # Queue JSONL is in .claude/projects/<encoded-path>/<session-id>.jsonl
+        queue = None
+        claude_projects = session_dir / ".claude" / "projects"
+        if claude_projects.exists():
+            for project_dir in claude_projects.iterdir():
+                if project_dir.is_dir():
+                    candidate = project_dir / f"{session_id}.jsonl"
+                    if candidate.exists():
+                        queue = candidate
+                        break
+
+        return cls(
+            session_dir=session_dir,
+            manifest_json=manifest,
+            audit_jsonl=audit,
+            queue_jsonl=queue,
+            session_id=session_id,
+        )
+
+
+@dataclass
+class DiagnosticResult:
+    """Results of a session health diagnosis."""
+
+    session_id: str = ""
+    audit_lines: int = 0
+    queue_lines: int = 0
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    info: list[str] = field(default_factory=list)
+    is_healthy: bool = True
+
+    def add_error(self, msg: str) -> None:
+        self.errors.append(msg)
+        self.is_healthy = False
+
+    def add_warning(self, msg: str) -> None:
+        self.warnings.append(msg)
+
+    def add_info(self, msg: str) -> None:
+        self.info.append(msg)
+
+    def format_report(self) -> str:
+        lines = [f"# Session Diagnosis: {self.session_id}", ""]
+        lines.append(f"**Status**: {'✅ HEALTHY' if self.is_healthy else '❌ UNHEALTHY'}")
+        lines.append(f"**Audit lines**: {self.audit_lines}")
+        lines.append(f"**Queue lines**: {self.queue_lines}")
+        lines.append("")
+
+        if self.errors:
+            lines.append("## Errors")
+            for e in self.errors:
+                lines.append(f"- ❌ {e}")
+            lines.append("")
+
+        if self.warnings:
+            lines.append("## Warnings")
+            for w in self.warnings:
+                lines.append(f"- ⚠️ {w}")
+            lines.append("")
+
+        if self.info:
+            lines.append("## Info")
+            for i in self.info:
+                lines.append(f"- ℹ️ {i}")
+            lines.append("")
+
+        return "\n".join(lines)
+
+
+def _parse_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Parse a JSONL file, returning a list of dicts. Skips malformed lines."""
+    entries: list[dict[str, Any]] = []
+    with open(path) as f:
+        for i, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError as e:
+                entries.append({"_parse_error": str(e), "_line_number": i, "_raw": line[:200]})
+    return entries
+
+
+def diagnose(paths: SessionPaths) -> DiagnosticResult:
+    """Run full diagnostic on a Cowork session."""
+    result = DiagnosticResult(session_id=paths.session_id)
+
+    # Check file existence
+    if not paths.manifest_json.exists():
+        result.add_error(f"Manifest JSON not found: {paths.manifest_json}")
+    if not paths.audit_jsonl.exists():
+        result.add_error(f"Audit JSONL not found: {paths.audit_jsonl}")
+        return result
+    if paths.queue_jsonl is None or not paths.queue_jsonl.exists():
+        result.add_error("Queue JSONL not found in .claude/projects/")
+        # Can still diagnose audit
+        paths.queue_jsonl = None
+
+    # Parse audit
+    audit_entries = _parse_jsonl(paths.audit_jsonl)
+    result.audit_lines = len(audit_entries)
+
+    # Check for parse errors in audit
+    parse_errors = [e for e in audit_entries if "_parse_error" in e]
+    if parse_errors:
+        for pe in parse_errors:
+            result.add_error(f"Malformed JSON at audit line {pe['_line_number']}: {pe['_parse_error']}")
+
+    # Analyze audit message types
+    audit_types = {}
+    for entry in audit_entries:
+        t = entry.get("type", "unknown")
+        audit_types[t] = audit_types.get(t, 0) + 1
+    result.add_info(f"Audit message types: {audit_types}")
+
+    # Check for dangling assistant message (no stop_reason on last assistant)
+    last_assistant = None
+    for entry in reversed(audit_entries):
+        if entry.get("type") == "assistant":
+            last_assistant = entry
+            break
+    if last_assistant:
+        sr = last_assistant.get("message", {}).get("stop_reason")
+        if sr is None:
+            result.add_error(f"Last assistant message has no stop_reason (stuck generation)")
+        else:
+            result.add_info(f"Last assistant stop_reason: {sr}")
+
+    # Check for orphaned tool_use (no matching tool_result)
+    pending_tool_ids: set[str] = set()
+    for entry in audit_entries:
+        content = entry.get("message", {}).get("content", [])
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict):
+                    if block.get("type") == "tool_use":
+                        pending_tool_ids.add(block.get("id", ""))
+                    elif block.get("type") == "tool_result":
+                        pending_tool_ids.discard(block.get("tool_use_id", ""))
+    if pending_tool_ids:
+        result.add_warning(f"Orphaned tool_use IDs (no tool_result): {pending_tool_ids}")
+
+    # Check for string-typed content in tool_result (should be array)
+    for i, entry in enumerate(audit_entries):
+        content = entry.get("message", {}).get("content", [])
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "tool_result":
+                    tc = block.get("content")
+                    if isinstance(tc, str):
+                        result.add_warning(
+                            f"Audit line {i}: tool_result content is string, should be array"
+                        )
+
+    # Check for synthetic/dummy message IDs (Gemini artifacts)
+    for i, entry in enumerate(audit_entries):
+        msg_id = entry.get("message", {}).get("id", "")
+        if "dummy" in msg_id:
+            result.add_warning(f"Audit line {i}: synthetic message ID detected: {msg_id}")
+
+    # Parse and analyze queue file
+    if paths.queue_jsonl and paths.queue_jsonl.exists():
+        queue_entries = _parse_jsonl(paths.queue_jsonl)
+        result.queue_lines = len(queue_entries)
+
+        # Check for parse errors
+        queue_parse_errors = [e for e in queue_entries if "_parse_error" in e]
+        if queue_parse_errors:
+            for pe in queue_parse_errors:
+                result.add_error(
+                    f"Malformed JSON at queue line {pe['_line_number']}: {pe['_parse_error']}"
+                )
+
+        # Check parentUuid chain
+        uuids_seen: set[str] = set()
+        for i, entry in enumerate(queue_entries):
+            uuid = entry.get("uuid", "")
+            parent = entry.get("parentUuid", "")
+            if uuid:
+                uuids_seen.add(uuid)
+            if parent and parent not in uuids_seen and i > 0:
+                result.add_error(
+                    f"Queue line {i}: parentUuid {parent[:16]}... not found in prior entries"
+                )
+
+        # Check queue types
+        queue_types = {}
+        for entry in queue_entries:
+            t = entry.get("type", "unknown")
+            queue_types[t] = queue_types.get(t, 0) + 1
+        result.add_info(f"Queue message types: {queue_types}")
+
+        # Check for string-typed content in queue
+        for i, entry in enumerate(queue_entries):
+            content = entry.get("message", {}).get("content", [])
+            if isinstance(content, list):
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "tool_result":
+                        tc = block.get("content")
+                        if isinstance(tc, str):
+                            result.add_warning(
+                                f"Queue line {i}: tool_result content is string, should be array"
+                            )
+
+        # Check session ID consistency
+        for i, entry in enumerate(queue_entries):
+            sid = entry.get("sessionId", "")
+            if sid and sid != paths.session_id:
+                result.add_error(
+                    f"Queue line {i}: sessionId mismatch: {sid} vs expected {paths.session_id}"
+                )
+
+    # Check manifest
+    if paths.manifest_json.exists():
+        try:
+            with open(paths.manifest_json) as f:
+                manifest = json.load(f)
+            title = manifest.get("title", "")
+            if "[FIXED" in title:
+                result.add_warning(f"Manifest title contains repair marker: {title}")
+            result.add_info(f"Session title: {title}")
+            result.add_info(f"Model: {manifest.get('model', 'unknown')}")
+        except json.JSONDecodeError as e:
+            result.add_error(f"Manifest JSON parse error: {e}")
+
+    return result
+
+
+def extract_transcript(paths: SessionPaths, output_path: Path | None = None) -> str:
+    """Extract a human-readable Markdown transcript from audit.jsonl.
+
+    Returns the transcript as a string and optionally writes to output_path.
+    """
+    if not paths.audit_jsonl.exists():
+        msg = f"Audit JSONL not found: {paths.audit_jsonl}"
+        raise FileNotFoundError(msg)
+
+    audit_entries = _parse_jsonl(paths.audit_jsonl)
+
+    lines: list[str] = []
+    lines.append(f"# Session Transcript: {paths.session_id}")
+    lines.append("")
+
+    # Extract files created/modified
+    files_touched: set[str] = set()
+    for entry in audit_entries:
+        content = entry.get("message", {}).get("content", [])
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    name = block.get("name", "")
+                    inp = block.get("input", {})
+                    if name in ("Write", "Edit") and isinstance(inp, dict):
+                        fp = inp.get("file_path", "")
+                        if fp:
+                            files_touched.add(fp)
+
+    if files_touched:
+        lines.append("## Files Created/Modified")
+        lines.append("")
+        for fp in sorted(files_touched):
+            lines.append(f"- `{fp}`")
+        lines.append("")
+
+    # Build transcript
+    lines.append("## Conversation")
+    lines.append("")
+
+    for entry in audit_entries:
+        if "_parse_error" in entry:
+            continue
+
+        entry_type = entry.get("type", "")
+        message = entry.get("message", {})
+        content = message.get("content", [])
+
+        if entry_type == "user" and isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict):
+                    if block.get("type") == "text":
+                        text = block.get("text", "")
+                        lines.append("### 👤 User")
+                        lines.append("")
+                        lines.append(text[:2000])
+                        if len(text) > 2000:
+                            lines.append(f"\n*[... truncated, {len(text)} chars total]*")
+                        lines.append("")
+                    elif block.get("type") == "tool_result":
+                        tool_id = block.get("tool_use_id", "")
+                        lines.append(f"*Tool result for `{tool_id[:20]}...`*")
+                        lines.append("")
+
+        elif entry_type == "assistant" and isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict):
+                    if block.get("type") == "text":
+                        text = block.get("text", "")
+                        lines.append("### 🤖 Assistant")
+                        lines.append("")
+                        lines.append(text[:2000])
+                        if len(text) > 2000:
+                            lines.append(f"\n*[... truncated, {len(text)} chars total]*")
+                        lines.append("")
+                    elif block.get("type") == "tool_use":
+                        name = block.get("name", "")
+                        inp = block.get("input", {})
+                        summary = ""
+                        if isinstance(inp, dict):
+                            if "file_path" in inp:
+                                summary = f" → `{inp['file_path']}`"
+                            elif "command" in inp:
+                                summary = f" → `{str(inp['command'])[:80]}`"
+                            elif "pattern" in inp:
+                                summary = f" → `{inp['pattern'][:60]}`"
+                        lines.append(f"**Tool: {name}**{summary}")
+                        lines.append("")
+
+    transcript = "\n".join(lines)
+
+    if output_path:
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(transcript)
+
+    return transcript
+
+
+def extract_artifacts_list(paths: SessionPaths) -> list[dict[str, str]]:
+    """Extract a list of all files created/modified during the session."""
+    if not paths.audit_jsonl.exists():
+        return []
+
+    audit_entries = _parse_jsonl(paths.audit_jsonl)
+    artifacts: list[dict[str, str]] = []
+    seen: set[str] = set()
+
+    for entry in audit_entries:
+        content = entry.get("message", {}).get("content", [])
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    name = block.get("name", "")
+                    inp = block.get("input", {})
+                    if name in ("Write", "Edit") and isinstance(inp, dict):
+                        fp = inp.get("file_path", "")
+                        if fp and fp not in seen:
+                            seen.add(fp)
+                            exists = os.path.exists(fp)
+                            size = os.path.getsize(fp) if exists else 0
+                            artifacts.append({
+                                "path": fp,
+                                "operation": name,
+                                "exists": str(exists),
+                                "size_bytes": str(size),
+                            })
+
+    return artifacts
+
+
+def backup_session(paths: SessionPaths, backup_dir: Path | None = None) -> Path:
+    """Create a timestamped backup of the session files."""
+    import shutil
+    from datetime import datetime, timezone
+
+    timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d-%H%M%S")
+    if backup_dir is None:
+        backup_dir = paths.session_dir.parent / f"{paths.session_dir.name}.backup-{timestamp}"
+    else:
+        backup_dir = backup_dir / f"{paths.session_dir.name}.backup-{timestamp}"
+
+    backup_dir.mkdir(parents=True, exist_ok=True)
+
+    # Copy session directory
+    shutil.copytree(paths.session_dir, backup_dir / paths.session_dir.name, dirs_exist_ok=True)
+
+    # Copy manifest
+    if paths.manifest_json.exists():
+        shutil.copy2(paths.manifest_json, backup_dir / paths.manifest_json.name)
+
+    return backup_dir
+
+
+def repair_queue(paths: SessionPaths, *, dry_run: bool = False) -> list[str]:
+    """Repair common issues in the queue JSONL file.
+
+    Returns a list of actions taken (or that would be taken in dry_run mode).
+    """
+    actions: list[str] = []
+
+    if paths.queue_jsonl is None or not paths.queue_jsonl.exists():
+        actions.append("ERROR: No queue file found")
+        return actions
+
+    queue_entries = _parse_jsonl(paths.queue_jsonl)
+
+    modified = False
+
+    # Fix 1: Remove synthetic/dummy entries (injected by repair tools)
+    clean_entries = []
+    for i, entry in enumerate(queue_entries):
+        msg_id = entry.get("message", {}).get("id", "")
+        if "dummy" in msg_id:
+            actions.append(f"REMOVE: Synthetic entry at line {i} (id={msg_id})")
+            modified = True
+        else:
+            clean_entries.append(entry)
+    queue_entries = clean_entries
+
+    # Fix 2: Fix string-typed tool_result content → array
+    for i, entry in enumerate(queue_entries):
+        content = entry.get("message", {}).get("content", [])
+        if isinstance(content, list):
+            for j, block in enumerate(content):
+                if isinstance(block, dict) and block.get("type") == "tool_result":
+                    tc = block.get("content")
+                    if isinstance(tc, str):
+                        entry["message"]["content"][j]["content"] = [{"type": "text", "text": tc}]
+                        actions.append(f"FIX: Queue line {i}, tool_result content string→array")
+                        modified = True
+
+    # Fix 3: Fix session ID mismatches
+    for i, entry in enumerate(queue_entries):
+        sid = entry.get("sessionId", "")
+        if sid and sid != paths.session_id:
+            entry["sessionId"] = paths.session_id
+            actions.append(f"FIX: Queue line {i}, sessionId {sid} → {paths.session_id}")
+            modified = True
+
+    # Fix 4: Ensure last-prompt entry is consistent
+    last_prompt_idx = None
+    for i, entry in enumerate(queue_entries):
+        if entry.get("type") == "last-prompt":
+            last_prompt_idx = i
+            lp_sid = entry.get("sessionId", "")
+            if lp_sid != paths.session_id:
+                entry["sessionId"] = paths.session_id
+                actions.append(f"FIX: last-prompt sessionId {lp_sid} → {paths.session_id}")
+                modified = True
+
+    if modified and not dry_run:
+        with open(paths.queue_jsonl, "w") as f:
+            for entry in queue_entries:
+                f.write(json.dumps(entry, separators=(",", ":")) + "\n")
+        actions.append(f"WRITTEN: {len(queue_entries)} entries to {paths.queue_jsonl}")
+
+    if not modified:
+        actions.append("No repairs needed")
+
+    return actions
+
+
+def validate_jsonl(path: Path) -> list[str]:
+    """Validate a JSONL file for structural integrity.
+
+    Returns a list of issues found (empty list = valid).
+    """
+    issues: list[str] = []
+    uuids: set[str] = set()
+
+    with open(path) as f:
+        for i, line in enumerate(f, 1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError as e:
+                issues.append(f"Line {i}: Invalid JSON: {e}")
+                continue
+
+            # Check UUID uniqueness
+            uuid = obj.get("uuid", "")
+            if uuid:
+                if uuid in uuids:
+                    issues.append(f"Line {i}: Duplicate UUID: {uuid}")
+                uuids.add(uuid)
+
+            # Check parentUuid references
+            parent = obj.get("parentUuid", "")
+            if parent and parent not in uuids and i > 1:
+                issues.append(f"Line {i}: Orphaned parentUuid: {parent[:24]}...")
+
+    return issues


### PR DESCRIPTION
## Summary

Addresses session data loss and startup crash scenarios caused by race conditions in process lifecycle management.

### Changes

**1. Graceful shutdown with pre-kill backup** (`native/backend.go`, `native/process.go`)
- `kill()` now sends SIGINT first and waits 3s for the Claude CLI to flush pending writes before escalating to SIGTERM
- `StopVM()` snapshots the session directory before killing processes (keeps 5 most recent backups)
- Prevents the root cause: SIGTERM killing the CLI mid-tool-execution before it can flush the queue JSONL

**2. Broken pipe race condition fix** (`native/process.go`)
- Adds a `ready` channel to `localProcess` that is closed when the first stdout/stderr output is received
- `writeStdin` waits for this channel (up to 5s) before writing, ensuring the CLI has initialized its stdin reader
- Prevents `failed to flush buffered stdin` errors when Desktop sends data immediately after spawn confirmation

**3. Startup integrity check** (`native/backend.go`)
- On VM startup, scans the sessions directory for truncated/empty audit.jsonl files
- Logs warnings for issues found (does not auto-repair for safety)
- Runs in background goroutine to avoid delaying VM startup

**4. Session doctor tool** (`scripts/cowork-session-doctor/`)
- Python CLI tool for diagnosing and repairing session JSONL files
- Commands: diagnose, repair, extract (markdown transcript), backup, validate
- Useful for debugging session corruption issues reported by users

### Testing
- Tested on Ubuntu 24.04 with native backend
- Verified graceful shutdown prevents JSONL truncation during active tool execution
- Verified broken pipe fix eliminates exit-code-1 crashes on rapid session starts