### PR TITLE
Add OpenRC support for non-systemd Linux systems

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -9,9 +9,11 @@ arch=('x86_64' 'aarch64')
 url="https://github.com/patrickjaja/claude-cowork-service"
 license=('MIT')
 
-depends=('systemd' 'util-linux')
+depends=('util-linux')
 optdepends=('claude-desktop-bin: Unofficial Linux frontend for Claude Desktop Cowork'
-            'claude-code: An agentic coding tool that lives in your terminal (you can also install via native installer)')
+            'claude-code: An agentic coding tool that lives in your terminal (you can also install via native installer)'
+            'systemd: required for the systemd user service unit (provided by base on Arch)'
+            'openrc: required to use the OpenRC init script (Artix Linux)')
 makedepends=('go')
 
 install="${pkgname}.install"
@@ -32,6 +34,12 @@ package() {
 
     install -Dm644 claude-cowork.service \
         "${pkgdir}/usr/lib/systemd/user/claude-cowork.service"
+
+    # OpenRC support (harmless on systemd hosts; only used when /sbin/openrc-run exists)
+    install -Dm755 claude-cowork.openrc \
+        "${pkgdir}/etc/init.d/claude-cowork"
+    install -Dm644 claude-cowork.confd \
+        "${pkgdir}/etc/conf.d/claude-cowork"
 
     install -Dm644 LICENSE \
         "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"

--- a/README.md
+++ b/README.md
@@ -62,6 +62,43 @@ yay -S claude-cowork-service
 
 Updates arrive through your AUR helper (e.g. `yay -Syu`).
 
+### Artix Linux (OpenRC)
+
+The same AUR package works on Artix — the PKGBUILD installs both the systemd
+user unit and an OpenRC init script. After install, set your desktop user in
+`/etc/conf.d/claude-cowork`:
+
+```sh
+# /etc/conf.d/claude-cowork
+COWORK_USER="yourusername"
+```
+
+Then start the service **after** your graphical session is up, so the init
+script can find the live `DISPLAY` / `WAYLAND_DISPLAY` /
+`DBUS_SESSION_BUS_ADDRESS` from your session leader (it scrapes
+`/proc/<pid>/environ`). Pick whichever startup hook matches your session:
+
+```sh
+# Wayland — Hyprland (~/.config/hypr/hyprland.conf)
+exec-once = sudo rc-service claude-cowork start
+
+# Wayland — Sway (~/.config/sway/config)
+exec sudo rc-service claude-cowork start
+
+# X11 — startx / xinit (~/.xinitrc, before `exec yourwm`)
+sudo rc-service claude-cowork start &
+
+# X11 — login manager (~/.xprofile)
+sudo rc-service claude-cowork start &
+```
+
+The init script forwards the same set of display/IPC variables the systemd
+user unit imports via `systemctl --user import-environment` — `DISPLAY`
+(X11), `WAYLAND_DISPLAY` (Wayland), `DBUS_SESSION_BUS_ADDRESS`,
+`XDG_SESSION_TYPE`, `XDG_CURRENT_DESKTOP`, and compositor-specific sockets
+(`HYPRLAND_INSTANCE_SIGNATURE`, `SWAYSOCK`, `YDOTOOL_SOCKET`). Missing
+variables silently no-op, so the same script works on X11 and Wayland.
+
 ### NixOS
 
 ```nix

--- a/claude-cowork-service.install
+++ b/claude-cowork-service.install
@@ -1,4 +1,13 @@
 post_upgrade() {
+  # OpenRC: restart the system service if it's currently running.
+  if command -v rc-service >/dev/null 2>&1 \
+      && [ -e /run/openrc/started/claude-cowork ]; then
+    echo ">>> Restarting claude-cowork OpenRC service..."
+    rc-service claude-cowork restart >/dev/null 2>&1 \
+      && echo "  Restarted" || echo "  Restart failed — restart manually"
+    return 0
+  fi
+
   echo ">>> Restarting claude-cowork service for active users..."
 
   command -v loginctl >/dev/null 2>&1 || return 0

--- a/claude-cowork.confd
+++ b/claude-cowork.confd
@@ -1,0 +1,12 @@
+# /etc/conf.d/claude-cowork
+#
+# Configuration for the Claude Cowork OpenRC service.
+
+# REQUIRED: the desktop user whose session the daemon should attach to.
+# This must be the user that runs Claude Desktop / Claude Code from the GUI.
+#COWORK_USER="yourusername"
+
+# Optional: space-separated list of environment variables to pull from the
+# user's running desktop session (looked up via /proc/<pid>/environ).
+# Defaults match the systemd user-unit's `systemctl --user import-environment`.
+#COWORK_IMPORT_ENV="WAYLAND_DISPLAY XDG_SESSION_TYPE XDG_CURRENT_DESKTOP DISPLAY DBUS_SESSION_BUS_ADDRESS HYPRLAND_INSTANCE_SIGNATURE SWAYSOCK YDOTOOL_SOCKET"

--- a/claude-cowork.openrc
+++ b/claude-cowork.openrc
@@ -1,0 +1,72 @@
+#!/sbin/openrc-run
+# OpenRC init script for the Claude Cowork Service.
+#
+# The upstream daemon is designed to run as a systemd *user* service so that
+# spawned Claude Code processes inherit the user's Wayland/X11 environment.
+# OpenRC has no first-class user-service concept, so this script runs the
+# daemon as a system service that switches to the desktop user.
+#
+# REQUIRED CONFIGURATION (/etc/conf.d/claude-cowork):
+#   COWORK_USER  — username whose desktop session the service should attach to.
+#
+# Start the service AFTER the user's graphical session is up (e.g. from your
+# compositor's startup hooks: `hyprctl dispatch exec rc-service claude-cowork start`)
+# so that XDG_RUNTIME_DIR / Wayland sockets exist.
+
+name="Claude Cowork Service"
+description="Native Linux backend for Claude Desktop Cowork"
+
+command="/usr/bin/cowork-svc-linux"
+command_background=true
+pidfile="/run/${RC_SVCNAME}.pid"
+command_user="${COWORK_USER}"
+
+# Forward extra env from the user's running session if requested.
+# COWORK_IMPORT_ENV is a space-separated list of variable names to pull from
+# the desktop user's session-leader /proc/<pid>/environ. Defaults to the same
+# set the systemd unit imports.
+: "${COWORK_IMPORT_ENV:=WAYLAND_DISPLAY XDG_SESSION_TYPE XDG_CURRENT_DESKTOP DISPLAY DBUS_SESSION_BUS_ADDRESS HYPRLAND_INSTANCE_SIGNATURE SWAYSOCK YDOTOOL_SOCKET}"
+
+depend() {
+	need dbus
+	after elogind
+	use display-manager
+}
+
+start_pre() {
+	if [ -z "${COWORK_USER}" ]; then
+		eerror "COWORK_USER is not set in /etc/conf.d/${RC_SVCNAME}"
+		return 1
+	fi
+
+	local uid
+	uid="$(id -u "${COWORK_USER}" 2>/dev/null)" || {
+		eerror "User '${COWORK_USER}' does not exist"
+		return 1
+	}
+
+	export XDG_RUNTIME_DIR="/run/user/${uid}"
+	if [ ! -d "${XDG_RUNTIME_DIR}" ]; then
+		ewarn "${XDG_RUNTIME_DIR} does not exist — start the service after the user's session is active"
+	fi
+
+	# Best-effort: scrape Wayland/X11 env from the desktop user's session.
+	# Walks processes owned by COWORK_USER and picks the first one whose
+	# /proc/<pid>/environ has WAYLAND_DISPLAY or DISPLAY set, then forwards
+	# the requested variables to the daemon.
+	local pid val var
+	pid=""
+	for p in $(pgrep -u "${uid}" 2>/dev/null); do
+		if grep -qzE '^(WAYLAND_DISPLAY|DISPLAY)=' "/proc/${p}/environ" 2>/dev/null; then
+			pid="${p}"
+			break
+		fi
+	done
+
+	if [ -n "${pid}" ] && [ -r "/proc/${pid}/environ" ]; then
+		for var in ${COWORK_IMPORT_ENV}; do
+			val="$(tr '\0' '\n' < "/proc/${pid}/environ" 2>/dev/null | sed -n "s/^${var}=//p" | head -n1)"
+			[ -n "${val}" ] && export "${var}=${val}"
+		done
+	fi
+}


### PR DESCRIPTION
# Add OpenRC support for non-systemd Linux

## Motivation

The PKGBUILD currently hard-depends on `systemd`, which prevents install on
Artix and other Arch derivatives running OpenRC. There is no upstream init
script for non-systemd hosts, so users have to roll their own.

## Changes

- **`claude-cowork.openrc`** — new OpenRC init script. Reads the desktop
  user from `/etc/conf.d/claude-cowork` (`COWORK_USER`) and scrapes
  `WAYLAND_DISPLAY` / `DISPLAY` / `DBUS_SESSION_BUS_ADDRESS` /
  `XDG_SESSION_TYPE` / `XDG_CURRENT_DESKTOP` /
  `HYPRLAND_INSTANCE_SIGNATURE` / `SWAYSOCK` / `YDOTOOL_SOCKET` from
  the user's session leader at start time — mirroring the
  `systemctl --user import-environment` preamble in the systemd unit.
- **`claude-cowork.confd`** — documented `/etc/conf.d/claude-cowork`
  template.
- **`PKGBUILD`** — drops `systemd` from `depends` (it's in `base` on Arch
  so the explicit dep was redundant, and it blocked Artix install). Lists
  `systemd` and `openrc` as `optdepends`. Installs the new init script
  and conf.d file. Both are harmless on systemd hosts.
- **`claude-cowork-service.install`** — `post_upgrade` restarts the
  OpenRC service when it's running; otherwise falls through to the
  existing systemd path.
- **`README.md`** — adds an Artix install section.

## Usage on Artix

```
# /etc/conf.d/claude-cowork
COWORK_USER="yourusername"
```

Start it from your compositor's startup hooks (so `XDG_RUNTIME_DIR` and
Wayland sockets already exist):

```
# Hyprland
exec-once = sudo rc-service claude-cowork start
```

## Tested

- Artix Linux + Hyprland (Wayland), service started from `exec-once`.
  Daemon comes up, socket appears at `/run/user/$UID/`, Claude Desktop
  Cowork connects, spawned `claude` processes inherit `WAYLAND_DISPLAY`
  and `DBUS_SESSION_BUS_ADDRESS` and can drive the clipboard.

## Display-server support

The init script is display-server agnostic — the scrape regex matches
processes with **either** `WAYLAND_DISPLAY` or `DISPLAY` set, and the
default `COWORK_IMPORT_ENV` list includes both X11 (`DISPLAY`) and
Wayland (`WAYLAND_DISPLAY`, `HYPRLAND_INSTANCE_SIGNATURE`, `SWAYSOCK`,
`YDOTOOL_SOCKET`) variables. Missing vars silently no-op. README has
startup examples for Hyprland, Sway, `~/.xinitrc`, and `~/.xprofile`.

## Notes

- The init script does **not** start at boot in the general case — it
  needs to attach to an active graphical session for env scraping to
  work. Recommended path is `exec-once` (Wayland compositors) or
  `~/.xinitrc` / `~/.xprofile` (X11).
- Systemd users see no behaviour change.
