### PR TITLE
fix(native): remove stdin readiness wait that adds a fixed 5s spawn latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to claude-cowork-service will be documented in this file.
 
 ## Unreleased
 
+### Fixed
+
+- Removed the stdin readiness wait in the native backend (`writeStdin`): it waited for the CLI's first output before writing, but with `--input-format stream-json` the CLI emits nothing until it receives input, so the 5s timeout fired deterministically and added a fixed ~5s startup latency to every session (`Spawn succeeded` ~5030ms vs <1s). The write path already guards the real failure modes with its own 10s timeout and the `<-lp.done` process-exit case; a broken pipe is only possible after process exit, which `<-lp.done` covers.
+
 ### Changed
+
 - Updated upstream reference materials from Claude Desktop v1.7196.0 to v1.8555.2
 - `installSdk` RPC params changed from `{name}` to `{sdkSubpath, version}` upstream (our handler is a no-op, no functional impact; struct already had the new fields)
 - `handleCreateDiskImage` and `SetCondaDiskPath` removed from upstream binary strings (our no-op handlers remain for backward compatibility)
@@ -23,11 +28,13 @@ All notable changes to claude-cowork-service will be documented in this file.
 ## 1.0.56 - 2026-05-11
 
 ### Added
+
 - Graceful shutdown with pre-kill backup - `kill()` now sends SIGINT first and waits 3s for the Claude CLI to flush pending writes before escalating to SIGTERM; `StopVM()` snapshots the session directory before killing processes (keeps 5 most recent backups)
 - Startup integrity check for session JSONL files - on VM startup, scans the sessions directory for truncated/empty audit.jsonl files and logs warnings (does not auto-repair for safety)
 - Session doctor tool (`scripts/cowork-session-doctor/`) - Python CLI for diagnosing and repairing session JSONL files (diagnose, repair, extract, backup, validate commands)
 
 ### Fixed
+
 - Broken pipe race condition on spawn - adds a `ready` channel to `localProcess` that waits for first stdout/stderr output (up to 5s) before writing stdin, preventing `failed to flush buffered stdin` errors when Desktop sends data immediately after spawn confirmation
 
 All changes in this section contributed by [@shmohammadi86](https://github.com/shmohammadi86) ([#41](https://github.com/patrickjaja/claude-cowork-service/pull/41)).
@@ -35,16 +42,19 @@ All changes in this section contributed by [@shmohammadi86](https://github.com/s
 ## 1.0.55 - 2026-05-11
 
 ### Fixed
+
 - `isProcessRunning` response now includes `exitCode` field alongside `running` - Desktop expects both fields for process health monitoring
 - Fix mount path canonicalization on systems where `/home` is a symlink to `/var/home` (Fedora Silverblue, Bazzite, CoreOS, Universal Blue) - `resolveSubpath()` now resolves symlinks when the fast string prefix check fails, preventing doubled paths like `/var/home/user/home/user/...` (#40)
 - Fix `hostAbsFromShared()` in VM backend incorrectly rejecting valid paths as "outside home" on symlinked home systems
 - Fix `ReadFile()` home containment check in VM backend to use canonicalized paths
 
 ### Changed
+
 - Updated upstream reference materials to Claude Desktop v1.6608.1 (rebuild-only release - no protocol, handler, or VM bundle changes vs 1.6608.0)
 - Updated upstream reference materials to Claude Desktop v1.6608.2 (rebuild with new tcpproxy dependency in cowork-svc.exe - no protocol, handler, or VM bundle changes vs 1.6608.1)
 
 ## 1.0.54 — 2026-05-07
+
 - **Upstream update to Claude Desktop v1.6608.0** (from v1.6259.0)
 - **Operon/Conda notebook engine completely removed from Desktop** - Massive internal refactoring that dropped the build size by approximately 3 MB. All conda-related code paths, the `createDiskImage` RPC method, and the `mountConda` spawn parameter are gone from the Desktop codebase.
 - **`createDiskImage` RPC removed** - Desktop no longer sends this method. Our no-op handler remains for backward compatibility.
@@ -62,6 +72,7 @@ All changes in this section contributed by [@shmohammadi86](https://github.com/s
 - **Updated reference docs** - COWORK_RPC_PROTOCOL.md, COWORK_SVC_BINARY.md, COWORK_VM_BUNDLE.md, CLAUDE.md, update-prompt.md updated to v1.6608.0
 
 ### Removed
+
 - **`createDiskImage` RPC method** - No longer sent by Desktop (Operon/Conda removed). Handler retained as no-op for backward compatibility.
 - **`mountConda` spawn parameter** - No longer sent by Desktop.
 - **`name` field from `addApprovedOauthToken`** - Desktop now sends only `{token}`.
@@ -69,10 +80,12 @@ All changes in this section contributed by [@shmohammadi86](https://github.com/s
 ## 1.0.53 — 2026-05-05
 
 ### Added
+
 - **`packaging/arch/build-pkg.sh`** — local pacman package builder. Mirrors the existing `build-deb.sh` / `build-rpm.sh` interface (`[--install] <binary> <version> [arch]`), generates a temporary PKGBUILD that wraps the prebuilt binary + systemd unit + install hook, runs `makepkg`, and drops a `claude-cowork-service-<ver>-1-<arch>.pkg.tar.zst` in the current directory. Pass `--install` to also `sudo pacman -U` the result.
 - **`memoryGB` parameter on `StartVM`** — backend interface is now `StartVM(name, bundlePath, memoryGB)`. KVM honours the per-call override and falls back to the value from `Configure(memoryMB,...)` when the caller passes `0`; native ignores it.
 
 ### Changed
+
 - **`StartVM` now receives the bundle path from the RPC layer** (`pipe/handlers.go`) — `pipe/handlers.go` forwards `params.BundlePath` to the backend so KVM can resolve the guest disk before launch instead of inferring it from the session name.
 - **`Spawn` vfs bind failure now returns an RPC error** (`vm/backend.go`) — previously the bind error path synthesised a `stderr` + `exit code 1` pair on the process channel and returned `nil`, so Desktop saw a "process started, then died" sequence with no actionable error. We now return the bind error directly so `spawn` fails loud and Desktop's normal error handling kicks in.
 - **Upstream update to Claude Desktop v1.6259.0** (from v1.5354.0)
@@ -88,6 +101,7 @@ All changes in this section contributed by [@shmohammadi86](https://github.com/s
 - **extract-cowork-svc.sh updated** - Script now extracts from MSIX package (`app/resources/`) instead of Squirrel nupkg (`lib/net45/resources/`), matching the current installer format
 
 ### Fixed
+
 - **KVM exit event key mismatch** (`vm/bridge.go`) — the guest emits exit events as `{"type":"event","event":"exit","params":{"code":N,...}}`, but the native backend's `process.ExitEvent` uses `"exitCode"`. The bridge was forwarding the guest's `"code"` verbatim, so KVM-mode clients saw a different field name than native-mode clients. Both the nested-event form and the direct-event form now rename `code` → `exitCode` before emit.
 - **`KvmBackend.allocateCID` race** (`vm/backend.go`) — the read-modify-write of `$baseDir/.next_cid` is now serialized with `syscall.Flock(LOCK_EX)` on the counter file. Without the lock, two concurrent daemons (daemon restart race, native↔kvm backend flip, user instance vs. systemd unit) — or two concurrent `StartVM` calls in the same process — could both read the same N and launch QEMU with duplicate `vhost-vsock-pci,guest-cid=N`. The kernel rejects the duplicate vsock binding, which surfaced as the generic `"QEMU exited immediately (check disk image or KVM access)"` error and pointed operators at disk/KVM instead of the real cause.
 - **`KvmBackend.StartVM` TOCTOU on `b.started`** (`vm/backend.go`) — the initial `started` check now also sets a `b.starting` sentinel under `b.mu`, cleared via `defer`, so two concurrent `StartVM` calls can no longer both pass the gate and each run the full boot pipeline. Previously the second commit at the end of `StartVM` would overwrite `b.qemu` / `b.qmp` / `b.helper` / `b.bridge` / `b.watchdogStop`, orphaning a full QEMU + virtiofsd pair that `StopVM` could not reach.
@@ -105,6 +119,7 @@ All changes in this section contributed by [@mosi0815](https://github.com/mosi08
 ## 1.0.52 — 2026-05-01
 
 ### Added
+
 - **KVM backend** (`-backend=kvm`) — new QEMU/KVM-based guest runtime that replaces the old dormant VM implementation. Selectable via the `-backend` flag or the `COWORK_VM_BACKEND` environment variable. Listens on a dedicated socket (`cowork-kvm-service.sock`) so native and KVM daemons can coexist in the same `$XDG_RUNTIME_DIR`. Native remains the default. Contributed by [@mosi0815](https://github.com/mosi0815) ([#26](https://github.com/patrickjaja/claude-cowork-service/pull/26)).
   - `vm/backend.go` — session lifecycle, bundle preparation, memory/CPU configuration, process management
   - `vm/bridge.go` — vsock host↔guest JSON message bridge
@@ -119,6 +134,7 @@ All changes in this section contributed by [@mosi0815](https://github.com/mosi08
 - **`-log-max-len` flag** — override the default 160-character budget.
 
 ### Changed
+
 - **Upstream update to Claude Desktop v1.5354.0** (from v1.4758.0)
 - **cowork-svc.exe**: Clean rebuild, same size (12,655,440 bytes), same Go version (go1.24.13). New SHA256 `026c6d2c163498e840b649049cbe3ce3fe451d9cac4dc1bf5077736b551f8cca`. Build date 2026-04-29, VCS revision `9a9e3d5a4a368f0f49a80dc303b0ed1a18bfedad`. No new RPC handler functions — identical handler set.
 - **VM bundle**: Unchanged — same SHA (`5680b11b...`), same file checksums (stable since v1.1.9669)
@@ -133,6 +149,7 @@ All changes in this section contributed by [@mosi0815](https://github.com/mosi08
 ## 1.0.51 — 2026-04-25
 
 ### Changed
+
 - **Upstream update to Claude Desktop v1.4758.0** (from v1.3883.0)
 - **cowork-svc.exe**: Rebuild, same size (12,655,440 bytes), same Go version (go1.24.13). New SHA256 `4ccc771f26fd2db82b072f6cf4c61af2802a737940bf5d4436b9a7d28cd9cbc8`. New internal features: client binary signature verification (WinVerifyTrust), VHDX sparse disk creation, persistent bidirectional RPC, plugin permission gating, conda/session disk support, idle session cleanup, log file ACL hardening. New source files: `variant.go`, `signature.go`, `vhdx.go`, `logfile_security.go`.
 - **VM bundle**: Unchanged — same SHA (`5680b11b...`), same file checksums (stable since v1.1.9669)
@@ -148,6 +165,7 @@ All changes in this section contributed by [@mosi0815](https://github.com/mosi08
 - **Updated reference docs** — `COWORK_RPC_PROTOCOL.md`, `COWORK_SVC_BINARY.md`, `COWORK_VM_BUNDLE.md` updated to v1.4758.0
 
 ### Added
+
 - **`userDataName` field in `configureParams` struct** (`pipe/handlers.go`) — accepts the new parameter from Desktop v1.4758.0
 - **`sessionOnly` field in `configureParams` struct** (`pipe/handlers.go`) — accepts fire-and-forget on-connect configure calls
 - **`userDataName` field in `vmNameParams` struct** (`pipe/handlers.go`) — accepts the new parameter in subscribeEvents
@@ -155,6 +173,7 @@ All changes in this section contributed by [@mosi0815](https://github.com/mosi08
 ## 1.0.50 — 2026-04-22
 
 ### Changed
+
 - **Upstream update to Claude Desktop v1.3883.0** (from v1.3561.0)
 - **cowork-svc.exe**: Minor rebuild (+512 bytes, 12,654,928 → 12,655,440 bytes), same Go version (go1.24.13). Build date 2026-04-21, VCS revision `93ff6cb984386882b4bd9b6bca80d4cf5af8e13b`. New `configure: %w` error wrapping (replaces `Config %`). No new RPC handler functions.
 - **VM bundle**: Unchanged — same SHA (`5680b11b...`), same file checksums
@@ -167,11 +186,13 @@ All changes in this section contributed by [@mosi0815](https://github.com/mosi08
 - **Updated reference docs** — `COWORK_RPC_PROTOCOL.md`, `COWORK_SVC_BINARY.md`, `COWORK_VM_BUNDLE.md` updated to v1.3883.0
 
 ### Fixed
+
 - **Reverse mount path remapping applied unconditionally** — `streamOutput()` applied `reverseMountRemap` (real host paths → VM `/sessions/` paths) even when `reverseMap=false` (native Linux without root). This caused bash command output (e.g., `wc -l` filenames) to contain `/sessions/<name>/mnt/...` paths that don't exist on disk, breaking subsequent model tool calls. Now both mount-level and session-level reverse mapping are gated behind the `reverseMap` flag.
 - **`readFile` RPC parameter mismatch** — Desktop sends `{processName, filePath}` and expects `{content}` in response. Our handler was parsing `{name, path}` and returning `{data}`. Fixed JSON tags and response field name. (Pre-existing bug, not introduced by v1.3883.0)
 - **`mountPath` RPC parameter mismatch** — Desktop sends `{processId, subpath, mountName, mode}`. Our handler was parsing `{name, hostPath, guestPath}`. Fixed JSON tags and updated VMBackend interface. (Pre-existing bug, not introduced by v1.3883.0; mountPath is a no-op in native mode so this had no functional impact)
 
 ### Changed (prior releases in this cycle)
+
 - **Prior upstream update to Claude Desktop v1.3561.0** (from v1.3109.0)
 - **cowork-svc.exe**: Minor rebuild (+6,656 bytes, 12,648,272 → 12,654,928 bytes), same Go version (go1.24.13). Build date 2026-04-20, VCS revision `fbc74be3fdc714a2c46ef1fb84f71d4e4c062930`. No new RPC handler functions; certificate date rotation in embedded TLS certs.
 - **Default socket path depends on backend** — native keeps the historical `cowork-vm-service.sock` for Desktop compatibility; KVM uses `cowork-kvm-service.sock` so Desktop can tell the two modes apart by which socket exists.
@@ -201,6 +222,7 @@ All changes in this section contributed by [@mosi0815](https://github.com/mosi08
 - **Prior upstream update to Claude Desktop v1.2773.0** (from v1.2581.0, commit `c17612d`): minor cowork-svc.exe rebuild (+512 bytes), SDK rolled back to 0.2.92, Desktop-side `[cowork-deletion]` event logging, `dispatchOnCliOpAlwaysAllowed`, `coworkWebSearchEnabled` gate removed.
 
 ### Removed
+
 - **Legacy VM implementation** — `vm/manager.go`, `vm/network.go`, `vm/vsock.go`, and `process/spawn.go` deleted. The new `vm/backend.go` + `vm/bridge.go` pair subsumes their roles (lifecycle, networking, vsock, process tracking) with a cleaner architecture built around QEMU/KVM and QMP.
 - **Root overlay boot mode** — the guest now boots directly off the converted root disk, so filesystem changes persist across reboots instead of being thrown away on every startup.
 
@@ -209,9 +231,11 @@ All changes in this section contributed by [@mosi0815](https://github.com/mosi08
 ## 1.0.48 — 2026-04-14
 
 ### Fixed
+
 - **APT install script hardcoded `arch=amd64`** — `packaging/apt/install.sh` and `packaging/apt/index.html` now detect architecture via `dpkg --print-architecture`, so ARM64 users (Raspberry Pi 5, Jetson, DGX Spark) get the correct `arm64` repo entry instead of a broken `amd64` one
 
 ### Added
+
 - **Nix aarch64-linux support** — `flake.nix` (`supportedSystems`) and `packaging/nix/package.nix` (`meta.platforms`) now include `aarch64-linux`
 - **Raspberry Pi 5** added to supported ARM64 devices in README
 
@@ -220,6 +244,7 @@ All changes in this section contributed by [@mosi0815](https://github.com/mosi08
 ## 1.0.46 — 2026-04-14
 
 ### Changed
+
 - **Upstream update to Claude Desktop v1.2581.0** (from v1.2278.0)
 - **cowork-svc.exe**: Clean rebuild, same size (12,643,664 bytes), same Go version (go1.24.13). No new RPC handler functions. Only build metadata changed (commit hash, timestamps)
 - **VM bundle**: Unchanged — same SHA (`5680b11b...`), same file checksums
@@ -234,16 +259,19 @@ All changes in this section contributed by [@mosi0815](https://github.com/mosi08
   - `cowork-plugin-shim.sh` updated — token gating (`cowork_require_token`), permission confirmation protocol (`cowork_gate`), multi-arch binary dispatch (`cowork_exec`)
 
 ### Fixed
+
 - **`apiReachability` event JSON field** — Desktop reads `s.status` but our struct used `json:"reachability"`. Changed to `json:"status"` to match actual wire protocol
 - **`startupStep` event missing `status` field** — Desktop guards with `s.step && s.status` and distinguishes `"started"` vs `"completed"`. Added `Status` field and emit both phases for each step
 
 ### Added
+
 - **`networkStatus` event type** — Desktop handles `case "networkStatus"` events with `"CONNECTED"` / `"NOT_CONNECTED"` status. Emitted as `"CONNECTED"` during native startup since host has direct network access
 - **Updated reference docs** — `COWORK_RPC_PROTOCOL.md` (9 event types), `COWORK_SVC_BINARY.md`, `COWORK_VM_BUNDLE.md` updated to v1.2581.0
 
 ## 1.0.45 — 2026-04-08
 
 ### Changed
+
 - **Upstream update to Claude Desktop v1.1617.0** (from v1.1348.0)
 - **cowork-svc.exe**: Rebuild with minor size increase (+1.5 KB, 11,177,808 → 11,179,344 bytes), same Go version (go1.24.13), no new RPC methods or handler functions. TLS certificate date rotation, updated build timestamps and VCS revision
 - **VM bundle**: Unchanged — same SHA (`5680b11b...`), same file checksums
@@ -265,9 +293,11 @@ All changes in this section contributed by [@mosi0815](https://github.com/mosi08
 ## 1.0.42 — 2026-04-03
 
 ### Fixed
+
 - **Double-nested home directory in symlink targets** — Claude Desktop v1.569.0+ changed `getVMStorageSubpath` to return root-relative subpaths (`home/user/.config/...`), causing `filepath.Join(home, relPath)` to produce doubled paths (`/home/user/home/user/.config/...`). Added `resolveSubpath()` helper that detects the format and resolves correctly. Fixes #16.
 
 ### Changed
+
 - **Upstream update to Claude Desktop v1.1062.0** (from v1.569.0)
 - **cowork-svc.exe**: Internal cert handling refactored (`enumerateRootStore`), new `vm/rpc_types.go` source file; binary shrank 8KB (11,186,000 → 11,177,808 bytes); same Go version (go1.24.13); no new RPC methods
 - **VM bundle**: Unchanged — same SHA (`5680b11b...`), same file checksums
@@ -290,10 +320,12 @@ All changes in this section contributed by [@mosi0815](https://github.com/mosi08
 ## 1.0.40 — 2026-04-02
 
 ### Fixed
+
 - **Dispatch file delivery**: Inject `--append-system-prompt` for dispatch sessions instructing the model to use `attachments` on `SendUserMessage` instead of `computer://` links that don't reach remote/mobile users
 - **present_files hint restored**: Re-add model hint in `present_files` response telling it to also call `SendUserMessage` with `attachments` (removed in df8037e when fixing INVALID_PATH)
 
 ### Changed
+
 - **Upstream update to Claude Desktop v1.569.0** (from v1.2.234)
 - **cowork-svc.exe**: New `handleSendGuestResponse` handler function; binary grew ~11KB (11,174,736 → 11,186,000 bytes); same Go version (go1.24.13)
 - **VM bundle**: Unchanged — same SHA (`5680b11b...`), same file checksums
@@ -301,6 +333,7 @@ All changes in this section contributed by [@mosi0815](https://github.com/mosi08
 - **Updated reference docs** — `COWORK_RPC_PROTOCOL.md`, `COWORK_SVC_BINARY.md`, `COWORK_VM_BUNDLE.md` updated to v1.569.0
 
 ### Added
+
 - **New RPC method `sendGuestResponse`** — Handler for plugin permission bridge guest responses; no-op on native Linux (filesystem-based permission bridge handles this directly)
 - Protocol now at **22 RPC methods**, 8 event types
 - **README: Systemd service documentation** — Documents `ExecStartPre` environment import, all 8 Wayland/display env vars, and why they're needed
@@ -312,6 +345,7 @@ All changes in this section contributed by [@mosi0815](https://github.com/mosi08
 ## 1.0.39 — 2026-04-01
 
 ### Changed
+
 - **Upstream update to Claude Desktop v1.2.234** (from v1.1.9669)
 - **cowork-svc.exe**: Rebuild only — same size (11,174,736 bytes), same Go version (go1.24.13), no new RPC methods or handler functions. Updated build timestamps and VCS revision
 - **VM bundle**: Unchanged — same SHA (`5680b11b...`), same file checksums
@@ -328,6 +362,7 @@ All changes in this section contributed by [@mosi0815](https://github.com/mosi08
 ## 1.0.37 — 2026-03-31
 
 ### Fixed
+
 - **claude-cowork.service**: Import Wayland/display environment variables (`WAYLAND_DISPLAY`, `XDG_SESSION_TYPE`, `XDG_CURRENT_DESKTOP`, `DISPLAY`, `DBUS_SESSION_BUS_ADDRESS`, `HYPRLAND_INSTANCE_SIGNATURE`, `SWAYSOCK`) via `ExecStartPre` so spawned CLI processes can access display and D-Bus services. Critical on Wayland-only systems (e.g. Ubuntu 25.10+). Fixes [#13](https://github.com/patrickjaja/claude-cowork-service/issues/13).
 
 ## 1.0.36 — 2026-03-31
@@ -353,12 +388,14 @@ All changes in this section contributed by [@mosi0815](https://github.com/mosi08
 ## 1.0.26 — 2026-03-30
 
 ### Added
+
 - **Upstream update to Claude Desktop v1.1.9669** (from v1.1.9493)
 - **3 new RPC handlers**: `getSessionsDiskInfo`, `deleteSessionDirs`, `createDiskImage` — all no-ops on native Linux (no virtual disks needed). Desktop's `VMDiskJanitor` and conda integration call these methods
 - **5 new spawn parameters**: `isResume`, `allowedDomains`, `oneShot`, `mountSkeletonHome`, `mountConda` — parsed from JSON but ignored on native (no VM/network isolation)
 - **Protocol now handles 21 RPC methods** (up from 18)
 
 ### Changed
+
 - **Updated reference docs** — `COWORK_RPC_PROTOCOL.md`, `COWORK_SVC_BINARY.md`, `COWORK_VM_BUNDLE.md` updated to v1.1.9669 with new checksums, methods, and version history
 - **VM bundle SHA**: `5680b11bcdab215cccf07e0c0bd1bd9213b0c25d` (all file checksums changed)
 - **New upstream file**: `cowork-plugin-shim.sh` — plugin permission gating library (filesystem-based request/response protocol)
@@ -369,11 +406,13 @@ All changes in this section contributed by [@mosi0815](https://github.com/mosi08
 ## 1.0.24 — 2026-03-29
 
 ### Fixed
+
 - **`present_files` INVALID_PATH error** — Return individual file paths as content items instead of a descriptive text message. Desktop's renderer treats each `{type:"text", text:...}` entry as a file path and calls `readLocalFile` on it; our previous response ("Files verified on disk (1). NOTE: ...") was passed verbatim as a path, causing `[INVALID_PATH] Path must be absolute`
 
 ## 1.0.23 — 2026-03-29
 
 ### Added
+
 - **Upstream protocol documentation** — Added comprehensive reference docs reverse-engineered from Claude Desktop v1.1.9493: `COWORK_RPC_PROTOCOL.md` (all 18 RPC methods, 8 event types, 12 protocol discoveries, Linux-specific adaptations, session lifecycle), `COWORK_SVC_BINARY.md` (Go binary internals, app.asar SDK versions, checksums), and `COWORK_VM_BUNDLE.md` (VM rootfs deep dive: sdk-daemon, Node.js, Python/npm packages, system packages)
 - **Automated version-check CI** — New `.github/workflows/version-check.yml` workflow polls `downloads.claude.ai` every 2 hours, creates a GitHub issue when a new Claude Desktop version is detected, and updates version badges on gh-pages (Claude Desktop tracking, APT, RPM, Nix)
 - **Version update playbook** — Added `update-prompt.md` with reusable prompts for the full update workflow (extract, diff protocol changes, audit Go code compatibility) and `UPDATE-PROMPT-CC-INPUT-MANUAL.md` as a quick-reference entry point
@@ -387,6 +426,7 @@ All changes in this section contributed by [@mosi0815](https://github.com/mosi08
 ## 1.0.21 — 2026-03-27
 
 ### Added
+
 - **Dispatch: full native Linux support** — Dispatch now works end-to-end on Linux. The Ditto orchestrator agent calls `SendUserMessage` natively (CLI v2.1.86 fix), text responses render on phone, and file delivery uses attachment hints
 - **Strip `--disallowedTools`** — Desktop passes VM-only tool restrictions (`AskUserQuestion`, `mcp__cowork__present_files`, `mcp__cowork__allow_cowork_file_delete`, `mcp__cowork__launch_code_session`, `mcp__cowork__create_artifact`, `mcp__cowork__update_artifact`). On native Linux we strip the entire flag since there is no VM runtime
 - **Local `present_files` interception** — Intercept `mcp__cowork__present_files` MCP control_requests in `streamOutput`, verify files exist on disk, and return synthetic success response. Desktop's handler rejects native Linux paths; this bypasses it entirely. Response includes hint to use `SendUserMessage` with `attachments` for mobile delivery
@@ -395,25 +435,30 @@ All changes in this section contributed by [@mosi0815](https://github.com/mosi08
 - **NixOS module evaluation tests in CI** — Verify module.nix produces correct systemd service config (ExecStart, Restart, wantedBy, extraPath wiring) via `nix flake check`
 
 ### Changed
+
 - **`--brief` injection is now conditional** — Only inject `--brief` when Desktop passes `CLAUDE_CODE_BRIEF=1` (for Ditto/dispatch sessions), not for regular cowork sessions. Desktop correctly differentiates: `lam_session_type:agent` gets BRIEF=1, `lam_session_type:chat` does not
 
 ### Removed
+
 - **Hardcoded binary fallback paths** — Removed Stage 4 fallback (`~/.npm-global/bin`, `~/.local/bin`, etc.) from binary resolution; stages 1-3 (LookPath, login shell, interactive shell) already resolve user-installed binaries reliably, and NixOS users now have `extraPath`
 
 ## 1.0.16 — 2026-03-23
 
 ### Changed
+
 - **SDK MCP proxy — pass `--mcp-config` through unchanged** — Stopped stripping SDK MCP servers from `--mcp-config`. Claude Desktop's session manager handles the bidirectional `control_request`/`control_response` MCP proxy over the event stream, identical to VM mode on Mac/Windows. This enables all per-session SDK tools: `mcp__dispatch__send_message`, `mcp__dispatch__start_task`, `mcp__cowork__present_files`, `mcp__session_info__read_transcript`, and more. Verified with 161 control_request/response pairs in test run, zero blocking.
 - **Removed `present_files` disallowedTools workaround** — No longer needed since the SDK MCP proxy gives the model native access to all cowork tools
 - **MCP proxy debug logging** — Detect and log `control_request` (CLI→Desktop) and `control_response` (Desktop→CLI) messages in stdout/stdin streams for observability
 
 ### Added
+
 - **`--brief` flag injection** — Inject `--brief` CLI flag when `CLAUDE_CODE_BRIEF=1` is in env (redundant safety measure for SendUserMessage availability)
 - **Dispatch debug logging** — Log `CLAUDE_CODE_BRIEF`, `--tools`, and `--allowedTools` at spawn time for dispatch debugging
 
 ## 1.0.15 — 2026-03-23
 
 ### Fixed
+
 - **ELOOP self-referencing symlink** — Prevent `.mcpb-cache` (and other child mounts) from becoming self-referencing symlinks when a parent mount is already symlinked; fixes `ELOOP: too many symbolic links encountered` on Dispatch/Cowork sessions with remote plugins
 - **Premature SIGTERM on Dispatch results** — Add 1s delay in kill RPC handler before sending SIGTERM, giving the result event time to propagate to the Electron renderer; fixes Dispatch responses completing successfully but never appearing in the UI
 
@@ -422,6 +467,7 @@ All changes in this section contributed by [@mosi0815](https://github.com/mosi08
 ## 1.0.12 — 2026-03-20
 
 ### Fixed
+
 - **Response ID propagation** — Echo back request `id` in all RPC responses so claude-desktop-bin's vm-client can match them; fixes "Orphaned response id=0 method response dropped" errors with claude-desktop-bin >= 1.1.7714
 - **`isGuestConnected` always true** — On native Linux the host IS the guest, so return `true` unconditionally; fixes "Request timed out: isGuestConnected" when claude-desktop-bin calls this before `startVM`
 - **Skip non-directory mounts** — Filter out mounts targeting files (e.g. `app.asar`) instead of symlinking them into the session; fixes "is not a directory" CLI error when Claude Desktop passes file mounts as `--add-dir`
@@ -429,10 +475,12 @@ All changes in this section contributed by [@mosi0815](https://github.com/mosi08
 ## 1.0.11 — 2026-03-19
 
 ### Added
+
 - **`isDebugLoggingEnabled` RPC** — Returns current debug logging state (matches Windows cowork-svc.exe protocol)
 - **`startupStep` events** — Emits `CERTIFICATE` and `VirtualDiskAttachments` startup progress events during `startVM` (matches Windows cowork-svc.exe protocol)
 
 ## 1.0.10 — 2026-03-04
 
 ### Fixed
+
 - **Binary PATH resolution** — Add interactive login shell fallback (`$SHELL -lic`) to resolve binaries when `bash -lc` misses PATH entries set in `.bashrc` behind interactive guards; also add `~/.npm-global/bin` to hardcoded fallback paths; fixes "Failed to sample" error in Cowork sessions when `claude` is installed via npm global

--- a/native/process.go
+++ b/native/process.go
@@ -33,8 +33,6 @@ type localProcess struct {
 	stdin             io.WriteCloser
 	done              chan struct{}
 	exitCode          int
-	ready             chan struct{} // closed when first output received, signaling stdin is safe
-	readyOnce         sync.Once    // ensures ready is closed exactly once
 	mu                sync.Mutex
 	vmPrefix          []byte      // e.g. "/sessions/optimistic-nice-brahmagupta"
 	realPrefix        []byte      // e.g. "/home/user/.local/share/claude-cowork/sessions/optimistic-nice-brahmagupta"
@@ -179,7 +177,6 @@ func (pt *processTracker) spawn(id string, cmd string, args []string, env map[st
 		cmd:               c,
 		stdin:             stdin,
 		done:              make(chan struct{}),
-		ready:             make(chan struct{}),
 		mountRemap:        mountRemap,
 		reverseMountRemap: reverseMountRemap,
 	}
@@ -281,15 +278,6 @@ func (pt *processTracker) streamOutput(id string, r io.Reader, stream string) {
 	scanner.Buffer(make([]byte, 64*1024), 10*1024*1024) // 10MB max for large Opus stream-json lines
 	for scanner.Scan() {
 		line := scanner.Text() + "\n"
-
-		// Signal that the CLI process is alive and producing output.
-		// writeStdin waits on this before sending data to avoid broken pipe
-		// errors when Desktop writes stdin before the CLI has initialized.
-		if lp != nil {
-			lp.readyOnce.Do(func() {
-				close(lp.ready)
-			})
-		}
 
 		// Remap real paths → VM paths in output (only when /sessions/ is accessible).
 		// Without this guard, native Linux (no root) would produce /sessions/ paths
@@ -658,18 +646,13 @@ func (pt *processTracker) writeStdin(processID string, data []byte) error {
 	default:
 	}
 
-	// Wait for the CLI to be ready before writing stdin.
-	// The broken pipe race condition occurs when Desktop sends stdin data
-	// before the CLI has fully initialized. We wait for the first output
-	// from the CLI (which signals it's alive and processing) before writing.
-	select {
-	case <-lp.ready:
-		// CLI is ready
-	case <-lp.done:
-		return fmt.Errorf("process %s exited before becoming ready", processID)
-	case <-time.After(5 * time.Second):
-		log.Printf("[native] WARNING: %s not ready after 5s, proceeding with stdin write anyway", processID)
-	}
+	// No readiness wait before writing (see ac1f482 / PR #41 for the original
+	// rationale): with --input-format stream-json the CLI produces no output
+	// until it receives input, so the wait always hit its 5s timeout and then
+	// wrote anyway - a fixed 5s startup delay on every session with no
+	// protection gained. Process-exit races are covered by the pre-write done
+	// check above and the <-lp.done case in the write select below; early
+	// writes while a healthy CLI initializes simply land in the pipe buffer.
 
 	// Write with timeout to avoid blocking forever if stdin buffer is full
 	type writeResult struct{ err error }


### PR DESCRIPTION
# Body

Fixes #62.

## What

Removes the readiness wait in `writeStdin` (and the now-unused `ready`/`readyOnce` fields on `localProcess`). See the issue for full diagnosis and measurements.

## Why it's safe

- The pre-write done check and the `<-lp.done` case in the write select predate #41 and already return a clean error when the process exited before or during the write — a broken pipe is only possible once the process has exited.
- With `--input-format stream-json` (all Desktop-spawned sessions) the wait never succeeds: the CLI emits nothing until it receives input, so current behavior is "sleep 5s, then write blind". The residual crash window (process dies after the write is buffered but before reading it) is identical before and after this change.
- A healthy CLI that is still initializing reads the buffered stdin once ready; pipe buffers absorb the early write.

## Effect

`Spawn succeeded` drops from a deterministic ~5030ms to sub-second; the `[native] WARNING: … not ready after 5s` journal spam disappears. Especially visible on Dispatch, which spawns an orchestrator + a child session per task.

## Testing

- `make test` green (native, pipe, vm); `go build ./...` / `go vet` clean
- Field-validated on the real RPC path (Arch Linux, CLI 2.1.167): patched binary on an isolated socket, raw `spawn` + immediate `writeStdin` of a stream-json user message → `writeStdin` returns in ~0ms (was a deterministic ~5000ms), model `result` event streams back 4.1s later. No broken pipe; the early write is buffered and consumed by the CLI during init.
- Pre-patch baseline from production logs on the same host: `not ready after 5s` warning + `Spawn succeeded in 5033/5030/5047ms` on every dispatch spawn.

CHANGELOG updated under Unreleased → Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
